### PR TITLE
Added option to disable URI validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Optionally, the following parameters can be set in the `RdfXmlParser` constructo
 * `strict`: If the internal SAX parser should parse XML in strict mode, and error if it is invalid. _(Default: `false`)_
 * `trackPosition`: If the internal position (line, column) should be tracked an emitted in error messages. _(Default: `false`)_
 * `allowDuplicateRdfIds`: By default [multiple occurrences of the same `rdf:ID` value are not allowed](https://www.w3.org/TR/rdf-syntax-grammar/#section-Syntax-ID-xml-base). By setting this option to `true`, this uniqueness check can be disabled. _(Default: `false`)_
+* `validateUri`: By default, the parser validates each URI. _(Default: `true`)_
 
 ```javascript
 new RdfXmlParser({
@@ -104,6 +105,7 @@ new RdfXmlParser({
   strict: true,
   trackPosition: true,
   allowDuplicateRdfIds: true,
+  validateUri: true,
 });
 ```
 

--- a/lib/RdfXmlParser.ts
+++ b/lib/RdfXmlParser.ts
@@ -80,10 +80,6 @@ export class RdfXmlParser extends Transform implements RDF.Sink<EventEmitter, RD
     this.attachSaxListeners();
   }
 
-  get uriValidationEnabled() {
-    return this.validateUri;
-  }
-
   /**
    * Check if the given IRI is valid.
    * @param {string} iri A potential IRI.
@@ -91,6 +87,10 @@ export class RdfXmlParser extends Transform implements RDF.Sink<EventEmitter, RD
    */
   public static isValidIri(iri: string): boolean {
     return RdfXmlParser.IRI_REGEX.test(iri);
+  }
+
+  get uriValidationEnabled() {
+    return this.validateUri;
   }
 
   /**

--- a/lib/RdfXmlParser.ts
+++ b/lib/RdfXmlParser.ts
@@ -50,6 +50,7 @@ export class RdfXmlParser extends Transform implements RDF.Sink<EventEmitter, RD
   private readonly defaultGraph?: RDF.Quad_Graph;
   private readonly allowDuplicateRdfIds?: boolean;
   private readonly saxParser: SaxesParser;
+  private readonly validateUri: boolean;
 
   private readonly activeTagStack: IActiveTag[] = [];
   private readonly nodeIds: {[id: string]: boolean} = {};
@@ -70,10 +71,17 @@ export class RdfXmlParser extends Transform implements RDF.Sink<EventEmitter, RD
     if (!this.defaultGraph) {
       this.defaultGraph = this.dataFactory.defaultGraph();
     }
+    if (this.validateUri !== false) {
+      this.validateUri = true;
+    }
 
     this.saxParser = new SaxesParser({ xmlns: true, position: this.trackPosition });
 
     this.attachSaxListeners();
+  }
+
+  get uriValidationEnabled() {
+    return this.validateUri;
   }
 
   /**
@@ -140,7 +148,7 @@ export class RdfXmlParser extends Transform implements RDF.Sink<EventEmitter, RD
    */
   public uriToNamedNode(uri: string): RDF.NamedNode {
     // Validate URI
-    if (!RdfXmlParser.isValidIri(uri)) {
+    if (this.uriValidationEnabled && !RdfXmlParser.isValidIri(uri)) {
       throw this.newParseError(`Invalid URI: ${uri}`);
     }
     return this.dataFactory.namedNode(uri);
@@ -688,6 +696,11 @@ export interface IRdfXmlParserArgs {
    * By setting this option to `true`, this uniqueness check can be disabled.
    */
   allowDuplicateRdfIds?: boolean;
+  /**
+   * Enables validation of all URIs. Will throw an Error in case of an invalid URI.
+   * By default, it is equal to true.
+   */
+  validateUri?: boolean;
 }
 
 export interface IActiveTag {

--- a/test/RdfXmlParser-test.ts
+++ b/test/RdfXmlParser-test.ts
@@ -25,6 +25,8 @@ describe('RdfXmlParser', () => {
     expect((<any> instance).baseIRI).toBe('');
     expect((<any> instance).defaultGraph).toBe(DF.defaultGraph());
     expect((<any> instance).saxParser).toBeInstanceOf(SaxesParser);
+    expect((<any> instance).validateUri).toBeTruthy();
+    expect(instance.uriValidationEnabled).toBeTruthy();
   });
 
   it('should be constructable with empty args', () => {
@@ -34,6 +36,8 @@ describe('RdfXmlParser', () => {
     expect((<any> instance).baseIRI).toBe('');
     expect((<any> instance).defaultGraph).toBe(DF.defaultGraph());
     expect((<any> instance).saxParser).toBeInstanceOf(SaxesParser);
+    expect((<any> instance).validateUri).toBeTruthy();
+    expect(instance.uriValidationEnabled).toBeTruthy();
   });
 
   it('should be constructable with args with a custom data factory', () => {
@@ -76,6 +80,13 @@ describe('RdfXmlParser', () => {
     expect((<any> instance).saxParser).toBeInstanceOf(SaxesParser);
   });
 
+  it('should be constructible with args with disabled validateUri', () => {
+    const instance = new RdfXmlParser({ validateUri: false });
+    expect(instance).toBeInstanceOf(RdfXmlParser);
+    expect((<any> instance).validateUri).toBeFalsy();
+    expect(instance.uriValidationEnabled).toBeFalsy();
+  });
+
   describe('#isValidIri', () => {
     it('should be false for null', async () => {
       expect(RdfXmlParser.isValidIri(null)).toBeFalsy();
@@ -111,7 +122,6 @@ describe('RdfXmlParser', () => {
   });
 
   describe('a default instance', () => {
-
     let parser: any;
 
     beforeEach(() => {
@@ -2362,6 +2372,27 @@ abc`)).rejects.toBeTruthy();
         streamParser.end();
         expect(streamParser.read(1)).toBeFalsy();
         expect(streamParser.writable).toBeFalsy();
+      });
+    });
+  });
+
+  describe('an instance with disabled URI validation', () => {
+    let parser: any;
+
+    beforeEach(() => {
+      parser = new RdfXmlParser({ validateUri: false });
+    });
+
+    describe('#valueToUri', () => {
+
+      it('ignore a URI with an invalid scheme', () => {
+        expect(() => parser.valueToUri('%https://example.com/', {}))
+          .not.toThrow(new Error('Invalid URI: %https://example.com/'));
+      });
+
+      it('ignore a URI with an invalid character', () => {
+        expect(() => parser.valueToUri('https://example.com/<', {}))
+          .not.toThrow(new Error('Invalid URI: https://example.com/<'));
       });
     });
   });


### PR DESCRIPTION
This PR is related to https://github.com/rdfjs/rdfxml-streaming-parser.js/issues/61

It is possible to set option "validateUri" to false and disable URI validation.