### PR TITLE
Uses validate-IRI library to validate IRIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,12 +90,13 @@ myParser.import(myTextStream)
 Optionally, the following parameters can be set in the `RdfXmlParser` constructor:
 
 * `dataFactory`: A custom [RDFJS DataFactory](http://rdf.js.org/#datafactory-interface) to construct terms and triples. _(Default: `require('@rdfjs/data-model')`)_
-* `baseIRI`: An initital default base IRI. _(Default: `''`)_
+* `baseIRI`: An initial default base IRI. _(Default: `''`)_
 * `defaultGraph`: The default graph for constructing [quads](http://rdf.js.org/#dom-datafactory-quad). _(Default: `defaultGraph()`)_
 * `strict`: If the internal SAX parser should parse XML in strict mode, and error if it is invalid. _(Default: `false`)_
 * `trackPosition`: If the internal position (line, column) should be tracked an emitted in error messages. _(Default: `false`)_
 * `allowDuplicateRdfIds`: By default [multiple occurrences of the same `rdf:ID` value are not allowed](https://www.w3.org/TR/rdf-syntax-grammar/#section-Syntax-ID-xml-base). By setting this option to `true`, this uniqueness check can be disabled. _(Default: `false`)_
 * `validateUri`: By default, the parser validates each URI. _(Default: `true`)_
+* `iriValidationStrategy`: Allows to customize the used IRI validation strategy using the `IriValidationStrategy` enumeration. _(Default: `IriValidationStrategy.Pragmatic`)_
 
 ```javascript
 new RdfXmlParser({

--- a/package.json
+++ b/package.json
@@ -95,7 +95,8 @@
     "rdf-data-factory": "^1.1.0",
     "relative-to-absolute-iri": "^1.0.0",
     "readable-stream": "^4.0.0",
-    "saxes": "^6.0.0"
+    "saxes": "^6.0.0",
+    "validate-iri": "^1.0.0"
   },
   "sideEffects": false
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3981,6 +3981,11 @@ v8-to-istanbul@^9.0.1:
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^1.6.0"
 
+validate-iri@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/validate-iri/-/validate-iri-1.0.0.tgz#a109600246e8a7515ecd238cdcddb7ca54b95d2d"
+  integrity sha512-4htbVgPOAS8RihVeyp/Pq5bnpKKhA2FcpsYTTION9rejFSZuIUX80SzO/+WMtSR3OVV1NFJx3J6DjrAZw83eCA==
+
 validate-npm-package-license@^3.0.1:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"


### PR DESCRIPTION
- By default the "pragmatic" mode is used (scheme validation + no invalid char according to RDF Turtle)
- The iriValidationStrategy option allows to customize the validation strategy
- It breaks the public API to remove dead code, not sure if it is welcomed

Benchmark using the GeoSpecies Knowledge Base (1.8M triples).
- no IRI validation: 8.338s
- pragmatic IRI validation: 9.116s
- full IRI validation: 12.053s
- 
Bug #39