### PR TITLE
Add support for namespace declaration using xmlns.

### DIFF
--- a/lib/RdfXmlParser.ts
+++ b/lib/RdfXmlParser.ts
@@ -517,6 +517,7 @@ while ${attribute.value} and ${activeSubjectValue} where found.`);
       // Interpret attributes at this point as properties via implicit blank nodes on the property,
       // but we ignore attributes that have no prefix or known expanded URI
       if (propertyAttribute.prefix !== 'xml' && propertyAttribute.prefix !== 'xmlns'
+          && (propertyAttribute.prefix !== '' || propertyAttribute.local !== 'xmlns')
         && propertyAttribute.uri) {
         if (parseType || activeTag.datatype) {
           throw this.newParseError(`Found illegal rdf:* properties on property element with attribute: ${

--- a/test/RdfXmlParser-test.ts
+++ b/test/RdfXmlParser-test.ts
@@ -930,6 +930,22 @@ abc`)).rejects.toBeTruthy();
           ]);
       });
 
+
+      it('declaration of the namespace on the element', async () => {
+        return expect(await parse(parser, `<?xml version="1.0"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <rdf:Description rdf:about="http://www.w3.org/TR/rdf-syntax-grammar">
+       <title xmlns="http://purl.org/dc/terms/" xml:lang="en">RDF1.1 XML Syntax</title>
+  </rdf:Description>
+</rdf:RDF>`))
+            .toBeRdfIsomorphic([
+              quad('http://www.w3.org/TR/rdf-syntax-grammar',
+                  'http://purl.org/dc/terms/title', '"RDF1.1 XML Syntax"@en'),
+            ]);
+      });
+
+
+
       it('DOCTYPE and ENTITY\'s', async () => {
         return expect(await parse(parser, `<!DOCTYPE rdf:RDF
 [<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">


### PR DESCRIPTION
Support for namespace declaration without prefix (the xmlns attribute) on an element. I.e. the following:

```
<?xml version="1.0"?>
<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
  <rdf:Description rdf:about="http://www.w3.org/TR/rdf-syntax-grammar">
       <title xmlns="http://purl.org/dc/terms/" xml:lang="en">RDF1.1 XML Syntax</title>
  </rdf:Description>
</rdf:RDF>
```

Should be correctly interpreted as a triple with a language literal as object. Without this fix the xmlns attribute is wrongly interpreted as a [property attribute](https://www.w3.org/TR/rdf-syntax-grammar/#section-Syntax-property-attributes). Another   consequence is that the literal is interpreted as a blank node. 

The fix simply detects the xmlns attribute and makes sure it is not interpreted as a property attribute.
A testcase is provided as well.