### PR TITLE
Support namespace declarations on node elements and typed node elements

### DIFF
--- a/lib/RdfXmlParser.ts
+++ b/lib/RdfXmlParser.ts
@@ -306,7 +306,9 @@ while ${attribute.value} and ${activeSubjectValue} where found.`);
 
       // Interpret attributes at this point as properties on this node,
       // but we ignore attributes that have no prefix or known expanded URI
-      if (attribute.prefix !== 'xml' && attribute.uri) {
+      if (attribute.prefix !== 'xml' && attribute.prefix !== 'xmlns'
+          && (attribute.prefix !== '' || attribute.local !== 'xmlns')
+        && attribute.uri) {
         predicates.push(this.uriToNamedNode(attribute.uri + attribute.local));
         objects.push(attribute.value);
       }

--- a/test/RdfXmlParser-test.ts
+++ b/test/RdfXmlParser-test.ts
@@ -930,16 +930,54 @@ abc`)).rejects.toBeTruthy();
           ]);
       });
 
-
-      it('declaration of the namespace on the element', async () => {
+      it('declaration of the default namespace on the property element', async () => {
         return expect(await parse(parser, `<?xml version="1.0"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
-  <rdf:Description rdf:about="http://www.w3.org/TR/rdf-syntax-grammar">
+  <rdf:Description rdf:about="http://example.com">
        <title xmlns="http://purl.org/dc/terms/" xml:lang="en">RDF1.1 XML Syntax</title>
   </rdf:Description>
 </rdf:RDF>`))
             .toBeRdfIsomorphic([
-              quad('http://www.w3.org/TR/rdf-syntax-grammar',
+              quad('http://example.com',
+                  'http://purl.org/dc/terms/title', '"RDF1.1 XML Syntax"@en'),
+            ]);
+      });
+
+      it('declaration of the namespace on the property element', async () => {
+        return expect(await parse(parser, `<?xml version="1.0"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <rdf:Description rdf:about="http://example.com">
+       <dct:title xmlns:dct="http://purl.org/dc/terms/" xml:lang="en">RDF1.1 XML Syntax</dct:title>
+  </rdf:Description>
+</rdf:RDF>`))
+            .toBeRdfIsomorphic([
+              quad('http://example.com',
+                  'http://purl.org/dc/terms/title', '"RDF1.1 XML Syntax"@en'),
+            ]);
+      });
+
+      it('declaration of the namespace on the resource element', async () => {
+        return expect(await parse(parser, `<?xml version="1.0"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <rdf:Description rdf:about="http://example.com" xmlns:dct="http://purl.org/dc/terms/">
+       <dct:title xml:lang="en">RDF1.1 XML Syntax</dct:title>
+  </rdf:Description>
+</rdf:RDF>`))
+            .toBeRdfIsomorphic([
+              quad('http://example.com',
+                  'http://purl.org/dc/terms/title', '"RDF1.1 XML Syntax"@en'),
+            ]);
+      });
+
+      it('declaration of the default namespace on the resource element', async () => {
+        return expect(await parse(parser, `<?xml version="1.0"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <rdf:Description rdf:about="http://example.com" xmlns="http://purl.org/dc/terms/">
+       <title xml:lang="en">RDF1.1 XML Syntax</title>
+  </rdf:Description>
+</rdf:RDF>`))
+            .toBeRdfIsomorphic([
+              quad('http://example.com',
                   'http://purl.org/dc/terms/title', '"RDF1.1 XML Syntax"@en'),
             ]);
       });

--- a/test/RdfXmlParser-test.ts
+++ b/test/RdfXmlParser-test.ts
@@ -982,6 +982,19 @@ abc`)).rejects.toBeTruthy();
             ]);
       });
 
+
+      it('declaration of the namespace on a typed resource element', async () => {
+        return expect(await parse(parser, `<?xml version="1.0"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <dct:Standard rdf:about="http://example.com" xmlns:dct="http://purl.org/dc/terms/">
+  </dct:Standard>
+</rdf:RDF>`))
+            .toBeRdfIsomorphic([
+              quad('http://example.com',
+                  'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://purl.org/dc/terms/Standard'),
+            ]);
+      });
+
       it('cdata support', async () => {
         return expect(await parse(parser, `<?xml version="1.0"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dct="http://purl.org/dc/terms/" >

--- a/test/RdfXmlParser-test.ts
+++ b/test/RdfXmlParser-test.ts
@@ -957,7 +957,6 @@ abc`)).rejects.toBeTruthy();
             ]);
       });
 
-
       it('DOCTYPE and ENTITY\'s', async () => {
         return expect(await parse(parser, `<!DOCTYPE rdf:RDF
 [<!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#">


### PR DESCRIPTION
Previous fixes only worked for namespace declarations on property elements.
Due to the striped syntax this was not enough.

Introduced test (and fix) for node elements and typed node elements.
Also divided the tests so there are separate tests for default namespace and specific namespace declarations.  